### PR TITLE
fix: restore unlocode.md page

### DIFF
--- a/_code-lists/unlocode.md
+++ b/_code-lists/unlocode.md
@@ -1,0 +1,37 @@
+---
+layout: unlocode
+title: UN/LOCODE
+permalink: unlocode
+jsonid: unlocode
+label: UN/LOCODE
+comment: desc
+excludeFromList: true
+columns:
+  - 
+    title: Label
+    code: label
+  - 
+    title: Label With Diacritics
+    code: labelWithDiacritics
+  - 
+    title: Functions
+    code: unlcdv:functions
+    type: uri
+  - 
+    title: Country Code
+    code: unlcdv:countryCode
+    type: uri
+  - 
+    title: Country Subdivision
+    code: unlcdv:countrySubdivision
+    type: uri
+  - 
+    title: Latitude
+    code: geo:lat
+  - 
+    title: Longitude
+    code: geo:long
+---
+
+
+


### PR DESCRIPTION
unlcode.md page was accidentally removed, which causes 404 error for anchors on unclodes per country pages, This PR adds it back

https://test.uncefact.org/22A/unlocode#AEALS - confirms it's working now