### PR TITLE
Fixed columns on landing pages

### DIFF
--- a/_sass/pages/_home.scss
+++ b/_sass/pages/_home.scss
@@ -53,8 +53,16 @@
   }
 
   &__item {
-    @media screen and (min-width: $tablet-md) {
-      width: calc(50% - 20px);
+    .browse-types--two-columns & {
+      @media screen and (min-width: $tablet-md) {
+        width: calc(50% - 20px);
+      }
+    }
+
+    .browse-types--three-columns & {
+      @media screen and (min-width: $tablet-md) {
+        width: calc(33.3% - 20px);
+      }
     }
   }
 }
@@ -144,6 +152,8 @@
   }
 
   &__description {
+    text-align: left;
+
     @media screen and (min-width: $tablet-md) {
       font-size: 14px;
       line-height: 22px;

--- a/home.html
+++ b/home.html
@@ -9,7 +9,7 @@ class: home
     <p class="home-content__description">The UN/CEFACT Web Vocabularies are linked data representations of the UN/CEFACT
         Buy-Ship-Pay Reference Data Model, UN/LOCODE and Sustainability.</p>
     <div class="home-content__inner">
-        <ul class="browse-types">
+        <ul class="browse-types browse-types--two-columns">
             <li class="browse-type browse-types__item">
                 <a href="{{ 'about' | absolute_url }}" class="browse-type__title">
                     <svg xmlns="http://www.w3.org/2000/svg" width="17" height="20">

--- a/pages/about.html
+++ b/pages/about.html
@@ -24,7 +24,7 @@ class: white
         </form>
     </div>
     <div class="home-content__inner">
-        <ul class="browse-types">
+        <ul class="browse-types browse-types--three-columns">
             <li class="browse-type browse-types__item">
                 <a href="{{ 'classes' | absolute_url }}" class="browse-type__title">
                     <svg xmlns="http://www.w3.org/2000/svg" width="17" height="20">

--- a/pages/unlocode-about.html
+++ b/pages/unlocode-about.html
@@ -10,7 +10,7 @@ hideMenu: true
     <p class="home-content__description">The UN/LOCODE Web Vocabulary is a linked data representation of the UN/CEFACT
         Buy-Ship-Pay Reference Data Model.</p>
     <div class="home-content__inner">
-        <ul class="browse-types">
+        <ul class="browse-types browse-types--three-columns">
             <li class="browse-type browse-types__item">
                 <a href="{{ 'unlocode-countries' | absolute_url }}" class="browse-type__title">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">


### PR DESCRIPTION
Fixes the boxes width on the landing 'about' page with 3 boxes page https://vocabulary.uncefact.org/about 
The fix is available for review at https://test.uncefact.org/22A/about